### PR TITLE
Fixed xref for adoc files

### DIFF
--- a/docs/modules/ROOT/pages/rp/items/index.adoc
+++ b/docs/modules/ROOT/pages/rp/items/index.adoc
@@ -5,30 +5,30 @@ The items are categorized into Parts, Advanced Parts, and Fluids, as used in var
 
 == Parts
 
-- link:photovoltaic_cells.adoc[Photovoltaic Cells] [Missing Documentation]
-- link:carbon_dust.adoc[Carbon Dust] [Missing Documentation]
-- link:carbon_mesh.adoc[Carbon Mesh] [Missing Documentation]
-- link:reinforced_carbon_carbon.adoc[Reinforced Carbon-Carbon] [Missing Documentation]
-- link:enriched_thorium.adoc[Enriched Thorium]
+- xref:photovoltaic_cells.adoc[Photovoltaic Cells] [Missing Documentation]
+- xref:carbon_dust.adoc[Carbon Dust] [Missing Documentation]
+- xref:carbon_mesh.adoc[Carbon Mesh] [Missing Documentation]
+- xref:reinforced_carbon_carbon.adoc[Reinforced Carbon-Carbon] [Missing Documentation]
+- xref:enriched_thorium.adoc[Enriched Thorium]
 
 == Advanced Parts
 
-- link:d-t_reactor_core.adoc[D-T Reactor Core]
-- link:coolant_powder.adoc[Coolant Powder]
-- link:advanced_reactor_casing.adoc[Advanced Reactor Casing]
+- xref:d-t_reactor_core.adoc[D-T Reactor Core]
+- xref:coolant_powder.adoc[Coolant Powder]
+- xref:advanced_reactor_casing.adoc[Advanced Reactor Casing]
 
 == Fluids
 
-- link:deanorium.adoc[Deanorium]
-- link:concentrated_deanium.adoc[Concentrated Deanium]
-- link:d-t_blend.adoc[D-T Blend]
-- link:liquid_tritium.adoc[Liquid Tritium]
-- link:cloudy_coolant.adoc[Cloudy Coolant]
-- link:reactor_coolant.adoc[Reactor Coolant]
-- link:methane_gas.adoc[Methane Gas]
-- link:high_pressure_steam.adoc[High Pressure Steam]
-- link:low_pressure_steam.adoc[Low Pressure Steam]
-- link:co2.adoc[CO₂]
+- xref:deanorium.adoc[Deanorium]
+- xref:concentrated_deanium.adoc[Concentrated Deanium]
+- xref:d-t_blend.adoc[D-T Blend]
+- xref:liquid_tritium.adoc[Liquid Tritium]
+- xref:cloudy_coolant.adoc[Cloudy Coolant]
+- xref:reactor_coolant.adoc[Reactor Coolant]
+- xref:methane_gas.adoc[Methane Gas]
+- xref:high_pressure_steam.adoc[High Pressure Steam]
+- xref:low_pressure_steam.adoc[Low Pressure Steam]
+- xref:co2.adoc[CO₂]
 
 == References and Links
 


### PR DESCRIPTION
The generated HTML documentation from the ADOC files is still pointing to ADOC files as it uses the "link" instruction instead of "xref"